### PR TITLE
Fedify MessageQueue를 NATS JetStream 기반으로 구현

### DIFF
--- a/packages/fedify-nats-message-queue/index.ts
+++ b/packages/fedify-nats-message-queue/index.ts
@@ -1,0 +1,94 @@
+import { AckPolicy, DeliverPolicy } from '@nats-io/jetstream';
+import type {
+  MessageQueue,
+  MessageQueueEnqueueOptions,
+  MessageQueueListenOptions,
+} from '@fedify/fedify';
+import type { JetStreamClient } from '@nats-io/jetstream';
+
+type QueueMessage = unknown;
+
+interface NatsMessageQueueOptions {
+  js: JetStreamClient;
+  streamName: string;
+  subject: string;
+  consumerName?: string;
+  maxDeliver?: number;
+}
+
+export class NatsMessageQueue implements MessageQueue {
+  readonly nativeRetrial = true;
+
+  #js: JetStreamClient;
+  #streamName: string;
+  #subject: string;
+  #consumerName: string;
+  #maxDeliver: number;
+
+  constructor(options: NatsMessageQueueOptions) {
+    this.#js = options.js;
+    this.#streamName = options.streamName;
+    this.#subject = options.subject;
+    this.#consumerName = options.consumerName ?? 'fedify-worker';
+    this.#maxDeliver = options.maxDeliver ?? 20;
+  }
+
+  async enqueue(message: QueueMessage, options?: MessageQueueEnqueueOptions): Promise<void> {
+    if (options?.delay) {
+      const delayMs = options.delay.total('millisecond');
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
+    await this.#js.publish(this.#subject, JSON.stringify(message));
+  }
+
+  async listen(
+    handler: (message: QueueMessage) => Promise<void> | void,
+    options?: MessageQueueListenOptions,
+  ): Promise<void> {
+    const signal = options?.signal;
+
+    const jsm = await this.#js.jetstreamManager();
+    await jsm.consumers.add(this.#streamName, {
+      durable_name: this.#consumerName,
+      ack_policy: AckPolicy.Explicit,
+      deliver_policy: DeliverPolicy.All,
+      max_deliver: this.#maxDeliver,
+    });
+
+    const consumer = await this.#js.consumers.get(this.#streamName, this.#consumerName);
+    const decoder = new TextDecoder();
+
+    while (!signal?.aborted) {
+      try {
+        const messages = await consumer.consume();
+
+        signal?.addEventListener(
+          'abort',
+          () => {
+            messages.stop();
+          },
+          { once: true },
+        );
+
+        for await (const m of messages) {
+          if (signal?.aborted) {
+            break;
+          }
+          try {
+            const payload = JSON.parse(decoder.decode(m.data));
+            await handler(payload);
+            m.ack();
+          } catch {
+            m.nak();
+          }
+        }
+      } catch {
+        if (signal?.aborted) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+  }
+}

--- a/packages/fedify-nats-message-queue/package.json
+++ b/packages/fedify-nats-message-queue/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kosmo/fedify-nats-message-queue",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {
+    "@fedify/fedify": "^1.8.8",
+    "@nats-io/jetstream": "^3.3.0"
+  }
+}

--- a/packages/nats/nats.ts
+++ b/packages/nats/nats.ts
@@ -12,12 +12,21 @@ export const nc: NatsConnection = await connect({
 
 export const js: JetStreamClient = jetstream(nc);
 export const streamName = 'jobs';
+export const fedifyStreamName = 'fedify';
+export const fedifySubject = 'fedify.messages';
 
 const jsm = await js.jetstreamManager();
 
 await jsm.streams.add({
   name: streamName,
   subjects: ['*'],
+  retention: RetentionPolicy.Workqueue,
+  discard: DiscardPolicy.New,
+});
+
+await jsm.streams.add({
+  name: fedifyStreamName,
+  subjects: ['fedify.>'],
   retention: RetentionPolicy.Workqueue,
   discard: DiscardPolicy.New,
 });

--- a/packages/service/activitypub/federation/index.ts
+++ b/packages/service/activitypub/federation/index.ts
@@ -16,6 +16,8 @@ import { AVATAR_FILE_ID, KOSMO_INSTANCE_ID } from '@kosmo/const';
 import { db, first, Instances, ProfileCryptographicKeys, Profiles } from '@kosmo/db';
 import { InstanceType, ProfileFollowAcceptMode } from '@kosmo/enum';
 import { env } from '@kosmo/env';
+import { NatsMessageQueue } from '@kosmo/fedify-nats-message-queue';
+import { fedifyStreamName, fedifySubject, js } from '@kosmo/nats';
 import { and, eq } from 'drizzle-orm';
 import * as R from 'remeda';
 import { followerCounter, followerDispatcher } from './dispatcher/follower';
@@ -28,6 +30,11 @@ import type { FederationContextData } from './type';
 
 export const federation = createFederation<FederationContextData>({
   kv: new MemoryKvStore(),
+  queue: new NatsMessageQueue({
+    js,
+    streamName: fedifyStreamName,
+    subject: fedifySubject,
+  }),
 });
 
 export const getFedifyContext = (domain: string) => {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@fedify/fedify": "^1.8.8",
+    "@kosmo/fedify-nats-message-queue": "workspace:*",
     "@kosmo/const": "workspace:*",
     "@kosmo/db": "workspace:*",
     "@kosmo/enum": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,15 @@ importers:
         specifier: ^8.43.0
         version: 8.43.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
 
+  packages/fedify-nats-message-queue:
+    dependencies:
+      '@fedify/fedify':
+        specifier: '>=1.8.15'
+        version: 1.10.2
+      '@nats-io/jetstream':
+        specifier: ^3.3.0
+        version: 3.3.0
+
   packages/i18n:
     devDependencies:
       '@kosmo/tsconfig':
@@ -678,6 +687,9 @@ importers:
       '@kosmo/error':
         specifier: workspace:*
         version: link:../error
+      '@kosmo/fedify-nats-message-queue':
+        specifier: workspace:*
+        version: link:../fedify-nats-message-queue
       '@kosmo/manager':
         specifier: workspace:*
         version: link:../manager


### PR DESCRIPTION
- @kosmo/fedify-nats-message-queue 패키지 신규 추가
- NATS JetStream 기반 NatsMessageQueue 클래스 구현
- fedify 전용 스트림/서브젝트 추가 (nats.ts)
- service/federation에서 NatsMessageQueue 적용


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
