### PR TITLE
Expo 메뉴 탭 UI 추가

### DIFF
--- a/apps/expo/src/app/(main)/profile.tsx
+++ b/apps/expo/src/app/(main)/profile.tsx
@@ -1,11 +1,60 @@
-import TimelineScreen from '@/components/feed/TimelineScreen';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import AccountMenuContent from '@/components/menu/AccountMenuContent';
 
-export default function ProfilePage() {
+export default function MenuPage() {
+  const insets = useSafeAreaInsets();
+
   return (
-    <TimelineScreen
-      eyebrow="Identity"
-      title="Profile"
-      description="프로필 헤더, 포스트 목록, 좋아요, 미디어 탭을 붙이기 위한 사용자 페이지입니다."
-    />
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={[
+        styles.content,
+        {
+          paddingTop: insets.top + 20,
+          paddingBottom: insets.bottom + 24,
+        },
+      ]}
+    >
+      <View style={styles.header}>
+        <Text style={styles.eyebrow}>Account</Text>
+        <Text style={styles.title}>메뉴</Text>
+        <Text style={styles.description}>
+          현재 프로필 전환과 계정 관련 작업을 한 곳에서 다루는 화면입니다.
+        </Text>
+      </View>
+      <AccountMenuContent />
+    </ScrollView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+  },
+  content: {
+    paddingHorizontal: 20,
+    gap: 24,
+  },
+  header: {
+    gap: 8,
+  },
+  eyebrow: {
+    color: '#2563eb',
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  title: {
+    color: '#0f172a',
+    fontSize: 32,
+    fontWeight: '800',
+  },
+  description: {
+    color: '#475569',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/apps/expo/src/components/menu/AccountMenuContent.tsx
+++ b/apps/expo/src/components/menu/AccountMenuContent.tsx
@@ -1,0 +1,151 @@
+import { Ionicons } from '@expo/vector-icons';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { accountActions, currentProfile, secondaryProfiles } from './accountData';
+
+type Props = {
+  onClose?: () => void;
+};
+
+export default function AccountMenuContent({ onClose }: Props) {
+  const handlePress = () => {
+    onClose?.();
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <View style={styles.cardHeader}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarLabel}>K</Text>
+          </View>
+          <View style={styles.cardBody}>
+            <Text style={styles.cardTitle}>{currentProfile.name}</Text>
+            <Text style={styles.cardHandle}>{currentProfile.handle}</Text>
+          </View>
+        </View>
+        <Text style={styles.cardDescription}>{currentProfile.bio}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionLabel}>프로필 전환</Text>
+        {secondaryProfiles.map((profile) => (
+          <Pressable
+            key={profile.id}
+            style={({ pressed }) => [styles.rowButton, pressed && styles.rowButtonPressed]}
+          >
+            <View style={styles.rowIcon}>
+              <Ionicons name="swap-horizontal" size={18} color="#0f172a" />
+            </View>
+            <View style={styles.rowBody}>
+              <Text style={styles.rowTitle}>{profile.name}</Text>
+              <Text style={styles.rowMeta}>{profile.handle}</Text>
+            </View>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionLabel}>빠른 메뉴</Text>
+        {accountActions.map((action) => (
+          <Pressable
+            key={action.id}
+            onPress={handlePress}
+            style={({ pressed }) => [styles.rowButton, pressed && styles.rowButtonPressed]}
+          >
+            <View style={styles.rowIcon}>
+              <Ionicons name={action.icon} size={18} color="#0f172a" />
+            </View>
+            <Text style={styles.rowTitle}>{action.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 20,
+  },
+  card: {
+    borderRadius: 20,
+    backgroundColor: '#eff6ff',
+    padding: 18,
+    gap: 12,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#2563eb',
+  },
+  avatarLabel: {
+    color: '#ffffff',
+    fontSize: 18,
+    fontWeight: '800',
+  },
+  cardBody: {
+    gap: 2,
+  },
+  cardTitle: {
+    color: '#0f172a',
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  cardHandle: {
+    color: '#475569',
+    fontSize: 14,
+  },
+  cardDescription: {
+    color: '#334155',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  section: {
+    gap: 10,
+  },
+  sectionLabel: {
+    color: '#64748b',
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  rowButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    borderRadius: 16,
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+  },
+  rowButtonPressed: {
+    backgroundColor: '#f8fafc',
+  },
+  rowIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#e2e8f0',
+  },
+  rowBody: {
+    gap: 2,
+  },
+  rowTitle: {
+    color: '#0f172a',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  rowMeta: {
+    color: '#64748b',
+    fontSize: 13,
+  },
+});

--- a/apps/expo/src/components/menu/DrawerContent.tsx
+++ b/apps/expo/src/components/menu/DrawerContent.tsx
@@ -1,9 +1,11 @@
+import { DrawerContentComponentProps } from '@react-navigation/drawer';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { navigationItems } from '@/components/navigation/navigationItems';
 import MenuButton from './MenuButton';
 
-export default function DrawerContent() {
+export default function DrawerContent(props: DrawerContentComponentProps) {
+  void props;
   const insets = useSafeAreaInsets();
 
   return (

--- a/apps/expo/src/components/menu/accountData.ts
+++ b/apps/expo/src/components/menu/accountData.ts
@@ -1,0 +1,42 @@
+type AccountAction = {
+  id: string;
+  label: string;
+  icon: 'person-outline' | 'people-outline' | 'settings-outline';
+};
+
+export const currentProfile = {
+  name: 'Kosmo Studio',
+  handle: '@kosmo',
+  bio: '현재 피드와 작성은 이 프로필 기준으로 동작합니다.',
+};
+
+export const secondaryProfiles = [
+  {
+    id: 'robin',
+    name: 'Robin Creator',
+    handle: '@robin',
+  },
+  {
+    id: 'team',
+    name: 'Team Ops',
+    handle: '@team',
+  },
+];
+
+export const accountActions: AccountAction[] = [
+  {
+    id: 'my-profile',
+    label: '내 프로필',
+    icon: 'person-outline',
+  },
+  {
+    id: 'manage-profiles',
+    label: '프로필 관리',
+    icon: 'people-outline',
+  },
+  {
+    id: 'settings',
+    label: '설정',
+    icon: 'settings-outline',
+  },
+] as const;

--- a/apps/expo/src/components/navigation/navigationItems.ts
+++ b/apps/expo/src/components/navigation/navigationItems.ts
@@ -40,9 +40,9 @@ export const navigationItems: NavigationItem[] = [
   },
   {
     href: '/profile',
-    label: '프로필',
-    title: 'Profile',
-    icon: 'person-outline',
-    activeIcon: 'person',
+    label: '메뉴',
+    title: 'Menu',
+    icon: 'grid-outline',
+    activeIcon: 'grid',
   },
 ];


### PR DESCRIPTION
- 모바일 하단 네비게이션에 5번째 메뉴 탭 구조를 추가함
- 메뉴 탭용 풀페이지 UI와 프로필 전환 카드 뼈대를 구성함
- 메뉴 탭에 필요한 Expo 라우트와 내비게이션 정의를 정리함

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
